### PR TITLE
[Fixes #529] Prevent NPE when context map is null

### DIFF
--- a/pax-logging-api/src/main/java/org/ops4j/pax/logging/slf4j/Slf4jMDCAdapter.java
+++ b/pax-logging-api/src/main/java/org/ops4j/pax/logging/slf4j/Slf4jMDCAdapter.java
@@ -17,6 +17,7 @@
  */
 package org.ops4j.pax.logging.slf4j;
 
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
@@ -88,6 +89,9 @@ public class Slf4jMDCAdapter implements MDCAdapter {
     public Map<String, String> getCopyOfContextMap() {
         Map<String, Object> copy = getContext().getCopyOfContextMap();
         Map<String, String> result = new HashMap<>();
+        if (copy == null) {
+            return Collections.emptyMap();
+        }
         copy.forEach((k, v) -> {
             if (v instanceof String) {
                 result.put(k, (String) v);


### PR DESCRIPTION
## Purpose
Fix the NPE issue when running the unit tests.

(cherry picked from commit c7a831315f8b48cbde6c2fb3564e0f6267303c6e)

