### PR TITLE
Update maven deploy plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
         <plugin.maven-shade-plugin>3.2.4</plugin.maven-shade-plugin>
         <plugin.maven-site-plugin>3.10.0</plugin.maven-site-plugin>
         <plugin.maven-source-plugin>3.2.1</plugin.maven-source-plugin>
-        <plugin.maven-surefire-plugin>2.22.2</plugin.maven-surefire-plugin>
+        <plugin.maven-surefire-plugin>3.1.0</plugin.maven-surefire-plugin>
         <version.plugin.maven-plugin-plugin>3.9.0</version.plugin.maven-plugin-plugin>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
         <plugin.maven-clean-plugin>3.1.0</plugin.maven-clean-plugin>
         <plugin.maven-compiler-plugin>3.8.1</plugin.maven-compiler-plugin>
         <plugin.maven-dependency-plugin>3.2.0</plugin.maven-dependency-plugin>
-        <plugin.maven-deploy-plugin>3.0.0</plugin.maven-deploy-plugin>
+        <plugin.maven-deploy-plugin>3.1.0</plugin.maven-deploy-plugin>
         <plugin.maven-enforcer-plugin>3.0.0</plugin.maven-enforcer-plugin>
         <plugin.dependency.org.commonjava.maven.enforcer>1.3</plugin.dependency.org.commonjava.maven.enforcer>
         <plugin.maven-failsafe-plugin>2.22.2</plugin.maven-failsafe-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
         <plugin.maven-clean-plugin>3.1.0</plugin.maven-clean-plugin>
         <plugin.maven-compiler-plugin>3.8.1</plugin.maven-compiler-plugin>
         <plugin.maven-dependency-plugin>3.2.0</plugin.maven-dependency-plugin>
-        <plugin.maven-deploy-plugin>2.8.2</plugin.maven-deploy-plugin>
+        <plugin.maven-deploy-plugin>3.0.0</plugin.maven-deploy-plugin>
         <plugin.maven-enforcer-plugin>3.0.0</plugin.maven-enforcer-plugin>
         <plugin.dependency.org.commonjava.maven.enforcer>1.3</plugin.dependency.org.commonjava.maven.enforcer>
         <plugin.maven-failsafe-plugin>2.22.2</plugin.maven-failsafe-plugin>


### PR DESCRIPTION
This downgrades the versions used in maven deploy plugin.
The maven version used in jenkins is 3.5.4 and this should be compatible with maven deploy version 3.1.0 and the maven sure fire version 3.1.0
https://maven.apache.org/plugins/maven-deploy-plugin/plugin-info.html