### PR TITLE
Removed the plugin for publishing artifacts to maven central during maven build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,6 @@
         <plugin.mojo.build-helper-maven-plugin>3.6.1</plugin.mojo.build-helper-maven-plugin>
         <plugin.mycila.license-maven-plugin>4.6</plugin.mycila.license-maven-plugin>
         <plugin.servicemix.depends-maven-plugin>1.5.0</plugin.servicemix.depends-maven-plugin>
-        <plugin.sonatype.central-publishing-maven-plugin>0.10.0</plugin.sonatype.central-publishing-maven-plugin>
         <plugin.sonatype.nexus-staging-maven-plugin>1.7.0</plugin.sonatype.nexus-staging-maven-plugin>
     </properties>
 
@@ -508,11 +507,6 @@
                     <version>${plugin.sonatype.nexus-staging-maven-plugin}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.central</groupId>
-                    <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>${plugin.sonatype.central-publishing-maven-plugin}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.ops4j.pax.exam</groupId>
                     <artifactId>exam-maven-plugin</artifactId>
                     <version>${version.org.ops4j.pax.exam}</version>
@@ -633,17 +627,6 @@
                     <skipLocalStaging>true</skipLocalStaging>
                     <skipRemoteStaging>true</skipRemoteStaging>
                     <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <!-- you need <server> with such <id> in ~/.m2/repository -->
-                    <publishingServerId>ossrh-central</publishingServerId>
-                    <deploymentName>pax-logging-${project.version}</deploymentName>
-                    <waitUntil>uploaded</waitUntil>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
## Purpose
This plugin was used in org.ops4j.pax.logging [1] and removed since we aren't pushing artifacts to maven central during maven build.

[1] https://github.com/ops4j/org.ops4j.pax.logging/blob/logging-2.3.2/pom.xml