### PR TITLE
Remove fasterxml imports to avoid issues with JsonTemplate

### DIFF
--- a/pax-logging-log4j2/osgi.bnd
+++ b/pax-logging-log4j2/osgi.bnd
@@ -46,22 +46,6 @@ Export-Package: \
 # for javax.* packages, those that are available in rt.jar (defined in Karaf's etc/jre.properties) are
 # listed here. Remaining ones (like `javax.mail`) are in extra bundle. (see PAXLOGGING-257).
 Import-Package: \
- com.fasterxml.jackson.annotation ;resolution:=optional, \
- com.fasterxml.jackson.core ;resolution:=optional, \
- com.fasterxml.jackson.core.type ;resolution:=optional, \
- com.fasterxml.jackson.core.util ;resolution:=optional, \
- com.fasterxml.jackson.databind ;resolution:=optional, \
- com.fasterxml.jackson.databind.annotation ;resolution:=optional, \
- com.fasterxml.jackson.databind.deser.std ;resolution:=optional, \
- com.fasterxml.jackson.databind.module ;resolution:=optional, \
- com.fasterxml.jackson.databind.node ;resolution:=optional, \
- com.fasterxml.jackson.databind.ser ;resolution:=optional, \
- com.fasterxml.jackson.databind.ser.impl ;resolution:=optional, \
- com.fasterxml.jackson.databind.ser.std ;resolution:=optional, \
- com.fasterxml.jackson.dataformat.xml ;resolution:=optional, \
- com.fasterxml.jackson.dataformat.xml.annotation ;resolution:=optional, \
- com.fasterxml.jackson.dataformat.xml.util ;resolution:=optional, \
- com.fasterxml.jackson.dataformat.yaml ;resolution:=optional, \
  javax.crypto, \
  javax.lang.model.element; resolution:=optional, \
  javax.lang.model; resolution:=optional, \


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

If not, we are getting the following error when using JsonLayout.

```
org.ops4j.pax.logging.pax-logging-api [log4j2] ERROR : Could not create plugin of type class org.apache.logging.log4j.core.layout.JsonLayout for element JsonLayout: java.lang.LinkageError: loader constraint violation: when resolving interface method 'void com.fasterxml.jackson.databind.Module$SetupContext.addDeserializers(com.fasterxml.jackson.databind.deser.Deserializers)' the class loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @3b1a7bb4 of the current class, org/apache/logging/log4j/core/jackson/Initializers$SetupContextInitializer, and the class loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @1db83d53 for the method's defining class, com/fasterxml/jackson/databind/Module$SetupContext, have different Class objects for the type com/fasterxml/jackson/databind/deser/Deserializers used in the signature (org.apache.logging.log4j.core.jackson.Initializers$SetupContextInitializer is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @3b1a7bb4, parent loader 'app'; com.fasterxml.jackson.databind.Module$SetupContext is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @1db83d53, parent loader 'app')
2026-03-03T16:09:26.554865Z Start Level: Equinox Container: a2a60cc3-58f1-40a2-aae3-bddfb4344549 ERROR Could not create plugin of type class org.apache.logging.log4j.core.layout.JsonLayout for element JsonLayout: java.lang.LinkageError: loader constraint violation: when resolving interface method 'void com.fasterxml.jackson.databind.Module$SetupContext.addDeserializers(com.fasterxml.jackson.databind.deser.Deserializers)' the class loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @3b1a7bb4 of the current class, org/apache/logging/log4j/core/jackson/Initializers$SetupContextInitializer, and the class loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @1db83d53 for the method's defining class, com/fasterxml/jackson/databind/Module$SetupContext, have different Class objects for the type com/fasterxml/jackson/databind/deser/Deserializers used in the signature (org.apache.logging.log4j.core.jackson.Initializers$SetupContextInitializer is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @3b1a7bb4, parent loader 'app'; com.fasterxml.jackson.databind.Module$SetupContext is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @1db83d53, parent loader 'app')
java.lang.LinkageError: loader constraint violation: when resolving interface method 'void com.fasterxml.jackson.databind.Module$SetupContext.addDeserializers(com.fasterxml.jackson.databind.deser.Deserializers)' the class loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @3b1a7bb4 of the current class, org/apache/logging/log4j/core/jackson/Initializers$SetupContextInitializer, and the class loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @1db83d53 for the method's defining class, com/fasterxml/jackson/databind/Module$SetupContext, have different Class objects for the type com/fasterxml/jackson/databind/deser/Deserializers used in the signature (org.apache.logging.log4j.core.jackson.Initializers$SetupContextInitializer is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @3b1a7bb4, parent loader 'app'; com.fasterxml.jackson.databind.Module$SetupContext is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @1db83d53, parent loader 'app')
	at org.apache.logging.log4j.core.jackson.Initializers$SetupContextInitializer.setupModule(Initializers.java:103)
	at org.apache.logging.log4j.core.jackson.Log4jJsonModule.setupModule(Log4jJsonModule.java:59)
	at com.fasterxml.jackson.databind.ObjectMapper.registerModule(ObjectMapper.java:906)
	at org.apache.logging.log4j.core.jackson.Log4jJsonObjectMapper.<init>(Log4jJsonObjectMapper.java:47)
	at org.apache.logging.log4j.core.layout.JacksonFactory$JSON.newObjectMapper(JacksonFactory.java:90)
	at org.apache.logging.log4j.core.layout.JacksonFactory.newWriter(JacksonFactory.java:276)
	at org.apache.logging.log4j.core.layout.JsonLayout.<init>(JsonLayout.java:214)
	at org.apache.logging.log4j.core.layout.JsonLayout.<init>(JsonLayout.java:70)
	at org.apache.logging.log4j.core.layout.JsonLayout$Builder.build(JsonLayout.java:116)
	at org.apache.logging.log4j.core.layout.JsonLayout$Builder.build(JsonLayout.java:78)
	at org.apache.logging.log4j.core.config.plugins.util.PluginBuilder.build(PluginBuilder.java:124)
	at org.apache.logging.log4j.core.config.AbstractConfiguration.createPluginObject(AbstractConfiguration.java:1214)
	at org.apache.logging.log4j.core.config.AbstractConfiguration.createConfiguration(AbstractConfiguration.java:1133)
	at org.apache.logging.log4j.core.config.AbstractConfiguration.createConfiguration(AbstractConfiguration.java:1125)
	at org.apache.logging.log4j.core.config.AbstractConfiguration.createConfiguration(AbstractConfiguration.java:1125)
	at org.apache.logging.log4j.core.config.AbstractConfiguration.doConfigure(AbstractConfiguration.java:718)
	at org.apache.logging.log4j.core.config.AbstractConfiguration.initialize(AbstractConfiguration.java:274)
	at org.apache.logging.log4j.core.config.AbstractConfiguration.start(AbstractConfiguration.java:327)
	at org.apache.logging.log4j.core.LoggerContext.setConfiguration(LoggerContext.java:697)
	at org.apache.logging.log4j.core.LoggerContext.reconfigure(LoggerContext.java:812)
```