### PR TITLE
Remove fasterxml imports to avoid issues with JsonTemplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+target
+# Ignore OS specific files
+.DS_Store

--- a/pax-logging-api-test/pom.xml
+++ b/pax-logging-api-test/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.wso2.org.ops4j.pax.logging</groupId>
         <artifactId>logging</artifactId>
-        <version>2.2.9-wso2v3-SNAPSHOT</version>
+        <version>2.2.9.1-wso2v1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pax-logging-api/pom.xml
+++ b/pax-logging-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.wso2.org.ops4j.pax.logging</groupId>
         <artifactId>logging</artifactId>
-        <version>2.2.9-wso2v3-SNAPSHOT</version>
+        <version>2.2.9.1-wso2v1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pax-logging-it/pom.xml
+++ b/pax-logging-it/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.wso2.org.ops4j.pax.logging</groupId>
         <artifactId>logging</artifactId>
-        <version>2.2.9-wso2v3-SNAPSHOT</version>
+        <version>2.2.9.1-wso2v1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pax-logging-log4j2-extra/pom.xml
+++ b/pax-logging-log4j2-extra/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.wso2.org.ops4j.pax.logging</groupId>
         <artifactId>logging</artifactId>
-        <version>2.2.9-wso2v3-SNAPSHOT</version>
+        <version>2.2.9.1-wso2v1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pax-logging-log4j2-maven-plugin/pom.xml
+++ b/pax-logging-log4j2-maven-plugin/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.wso2.org.ops4j.pax.logging</groupId>
         <artifactId>logging</artifactId>
-        <version>2.2.9-wso2v3-SNAPSHOT</version>
+        <version>2.2.9.1-wso2v1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pax-logging-log4j2/osgi.bnd
+++ b/pax-logging-log4j2/osgi.bnd
@@ -46,22 +46,6 @@ Export-Package: \
 # for javax.* packages, those that are available in rt.jar (defined in Karaf's etc/jre.properties) are
 # listed here. Remaining ones (like `javax.mail`) are in extra bundle. (see PAXLOGGING-257).
 Import-Package: \
- com.fasterxml.jackson.annotation ;resolution:=optional, \
- com.fasterxml.jackson.core ;resolution:=optional, \
- com.fasterxml.jackson.core.type ;resolution:=optional, \
- com.fasterxml.jackson.core.util ;resolution:=optional, \
- com.fasterxml.jackson.databind ;resolution:=optional, \
- com.fasterxml.jackson.databind.annotation ;resolution:=optional, \
- com.fasterxml.jackson.databind.deser.std ;resolution:=optional, \
- com.fasterxml.jackson.databind.module ;resolution:=optional, \
- com.fasterxml.jackson.databind.node ;resolution:=optional, \
- com.fasterxml.jackson.databind.ser ;resolution:=optional, \
- com.fasterxml.jackson.databind.ser.impl ;resolution:=optional, \
- com.fasterxml.jackson.databind.ser.std ;resolution:=optional, \
- com.fasterxml.jackson.dataformat.xml ;resolution:=optional, \
- com.fasterxml.jackson.dataformat.xml.annotation ;resolution:=optional, \
- com.fasterxml.jackson.dataformat.xml.util ;resolution:=optional, \
- com.fasterxml.jackson.dataformat.yaml ;resolution:=optional, \
  javax.crypto, \
  javax.lang.model.element; resolution:=optional, \
  javax.lang.model; resolution:=optional, \

--- a/pax-logging-log4j2/pom.xml
+++ b/pax-logging-log4j2/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.wso2.org.ops4j.pax.logging</groupId>
         <artifactId>logging</artifactId>
-        <version>2.2.9-wso2v3-SNAPSHOT</version>
+        <version>2.2.9.1-wso2v1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pax-logging-logback/pom.xml
+++ b/pax-logging-logback/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.wso2.org.ops4j.pax.logging</groupId>
         <artifactId>logging</artifactId>
-        <version>2.2.9-wso2v3-SNAPSHOT</version>
+        <version>2.2.9.1-wso2v1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pax-logging-samples/fragment-log4j2-h2/pom.xml
+++ b/pax-logging-samples/fragment-log4j2-h2/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.wso2.org.ops4j.pax.logging</groupId>
         <artifactId>pax-logging-samples</artifactId>
-        <version>2.2.9-wso2v3-SNAPSHOT</version>
+        <version>2.2.9.1-wso2v1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pax-logging-samples/fragment-log4j2/pom.xml
+++ b/pax-logging-samples/fragment-log4j2/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.wso2.org.ops4j.pax.logging</groupId>
         <artifactId>pax-logging-samples</artifactId>
-        <version>2.2.9-wso2v3-SNAPSHOT</version>
+        <version>2.2.9.1-wso2v1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pax-logging-samples/fragment-logback/pom.xml
+++ b/pax-logging-samples/fragment-logback/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.wso2.org.ops4j.pax.logging</groupId>
         <artifactId>pax-logging-samples</artifactId>
-        <version>2.2.9-wso2v3-SNAPSHOT</version>
+        <version>2.2.9.1-wso2v1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pax-logging-samples/pom.xml
+++ b/pax-logging-samples/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.wso2.org.ops4j.pax.logging</groupId>
         <artifactId>logging</artifactId>
-        <version>2.2.9-wso2v3-SNAPSHOT</version>
+        <version>2.2.9.1-wso2v1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
     <groupId>org.wso2.org.ops4j.pax.logging</groupId>
     <artifactId>logging</artifactId>
-    <version>2.2.9-wso2v3-SNAPSHOT</version>
+    <version>2.2.9.1-wso2v1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>OPS4J Pax Logging (Build POM)</name>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Remove fasterxml imports to avoid issues with JsonTemplate. This will only be used by MI product. Hence creating a separate branch.

Resolves https://github.com/wso2/product-micro-integrator/issues/4708