### PR TITLE
Remove central-publishing-maven-plugin (ossrh-central) config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,6 @@
         <plugin.mojo.build-helper-maven-plugin>3.6.1</plugin.mojo.build-helper-maven-plugin>
         <plugin.mycila.license-maven-plugin>4.6</plugin.mycila.license-maven-plugin>
         <plugin.servicemix.depends-maven-plugin>1.5.0</plugin.servicemix.depends-maven-plugin>
-        <plugin.sonatype.central-publishing-maven-plugin>0.10.0</plugin.sonatype.central-publishing-maven-plugin>
         <plugin.sonatype.nexus-staging-maven-plugin>1.7.0</plugin.sonatype.nexus-staging-maven-plugin>
     </properties>
 
@@ -503,11 +502,6 @@
                     <version>${plugin.sonatype.nexus-staging-maven-plugin}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.central</groupId>
-                    <artifactId>central-publishing-maven-plugin</artifactId>
-                    <version>${plugin.sonatype.central-publishing-maven-plugin}</version>
-                </plugin>
-                <plugin>
                     <groupId>org.ops4j.pax.exam</groupId>
                     <artifactId>exam-maven-plugin</artifactId>
                     <version>${version.org.ops4j.pax.exam}</version>
@@ -630,18 +624,6 @@
                     <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <!-- you need <server> with such <id> in ~/.m2/repository -->
-                    <publishingServerId>ossrh-central</publishingServerId>
-                    <deploymentName>pax-logging-${project.version}</deploymentName>
-                    <waitUntil>uploaded</waitUntil>
-                </configuration>
-            </plugin>
-
         </plugins>
     </build>
 


### PR DESCRIPTION
## Purpose

Remove the `central-publishing-maven-plugin` (`ossrh-central`) config so the official release build for this line can succeed.

Related: wso2/product-apim#18097

## Why

This plugin is ops4j's own Maven Central publishing mechanism (Sonatype's Central Publishing Portal), inherited from their upstream pom. It has no place in a WSO2-internal fork that deploys to WSO2's own Nexus instead, and its presence
appears to block the actual release build (as opposed to a regular snapshot build, which succeeds either way).

This mirrors the identical fix already applied on the `2.3.2-wso2vx` line ([`37ac0dec`](https://github.com/wso2/wso2-pax-logging/commit/37ac0dec515b011297fd9e91ab48c4f9c9a89621), "Removed the plugin for publishing artifacts to maven central during maven build"), which landed immediately before that line's first successful official release build.

## Changes

Removed from the root `pom.xml`:
- `plugin.sonatype.central-publishing-maven-plugin` version property
- `central-publishing-maven-plugin` `pluginManagement` declaration
- The active `central-publishing-maven-plugin` plugin block (`publishingServerId=ossrh-central`)

## Verification

- `mvn clean install -DskipTests` builds successfully across all 12 modules.
