### PR TITLE
Revert "Upgrade to Log4j2 2.25.5"

### DIFF
--- a/pax-logging-api/osgi.bnd
+++ b/pax-logging-api/osgi.bnd
@@ -84,7 +84,6 @@ Export-Package: \
  org.apache.logging.log4j;-split-package:=merge-first; version=2.23.1; provider=paxlogging, \
  org.apache.logging.log4j;-split-package:=merge-first; version=2.24.3; provider=paxlogging, \
  org.apache.logging.log4j;-split-package:=merge-first; version=2.24.4; provider=paxlogging, \
- org.apache.logging.log4j;-split-package:=merge-first; version=2.25.4; provider=paxlogging, \
  org.apache.logging.log4j.message; version=${version.org.apache.logging.log4j}; provider=paxlogging, \
  org.apache.logging.log4j.message; version=2.9.1; provider=paxlogging, \
  org.apache.logging.log4j.message; version=2.13.3; provider=paxlogging, \
@@ -97,7 +96,6 @@ Export-Package: \
  org.apache.logging.log4j.message; version=2.23.1; provider=paxlogging, \
  org.apache.logging.log4j.message; version=2.24.3; provider=paxlogging, \
  org.apache.logging.log4j.message; version=2.24.4; provider=paxlogging, \
- org.apache.logging.log4j.message; version=2.25.4; provider=paxlogging, \
  org.apache.logging.log4j.simple; version=${version.org.apache.logging.log4j}; provider=paxlogging, \
  org.apache.logging.log4j.simple; version=2.9.1; provider=paxlogging, \
  org.apache.logging.log4j.simple; version=2.13.3; provider=paxlogging, \
@@ -110,7 +108,6 @@ Export-Package: \
  org.apache.logging.log4j.simple; version=2.23.1; provider=paxlogging, \
  org.apache.logging.log4j.simple; version=2.24.3; provider=paxlogging, \
  org.apache.logging.log4j.simple; version=2.24.4; provider=paxlogging, \
- org.apache.logging.log4j.simple; version=2.25.4; provider=paxlogging, \
  org.apache.logging.log4j.spi; version=${version.org.apache.logging.log4j}; provider=paxlogging, \
  org.apache.logging.log4j.spi; version=2.9.1; provider=paxlogging, \
  org.apache.logging.log4j.spi; version=2.13.3; provider=paxlogging, \
@@ -123,7 +120,6 @@ Export-Package: \
  org.apache.logging.log4j.spi; version=2.23.1; provider=paxlogging, \
  org.apache.logging.log4j.spi; version=2.24.3; provider=paxlogging, \
  org.apache.logging.log4j.spi; version=2.24.4; provider=paxlogging, \
- org.apache.logging.log4j.spi; version=2.25.4; provider=paxlogging, \
  org.apache.logging.log4j.status;-split-package:=merge-first; version=${version.org.apache.logging.log4j}; provider=paxlogging, \
  org.apache.logging.log4j.status;-split-package:=merge-first; version=2.9.1; provider=paxlogging, \
  org.apache.logging.log4j.status;-split-package:=merge-first; version=2.13.3; provider=paxlogging, \
@@ -136,7 +132,6 @@ Export-Package: \
  org.apache.logging.log4j.status;-split-package:=merge-first; version=2.23.1; provider=paxlogging, \
  org.apache.logging.log4j.status;-split-package:=merge-first; version=2.24.3; provider=paxlogging, \
  org.apache.logging.log4j.status;-split-package:=merge-first; version=2.24.4; provider=paxlogging, \
- org.apache.logging.log4j.status;-split-package:=merge-first; version=2.25.4; provider=paxlogging, \
  org.apache.logging.log4j.util;-split-package:=merge-first; version=${version.org.apache.logging.log4j}; provider=paxlogging, \
  org.apache.logging.log4j.util;-split-package:=merge-first; version=2.9.1; provider=paxlogging, \
  org.apache.logging.log4j.util;-split-package:=merge-first; version=2.13.3; provider=paxlogging, \
@@ -149,7 +144,6 @@ Export-Package: \
  org.apache.logging.log4j.util;-split-package:=merge-first; version=2.23.1; provider=paxlogging, \
  org.apache.logging.log4j.util;-split-package:=merge-first; version=2.24.3; provider=paxlogging, \
  org.apache.logging.log4j.util;-split-package:=merge-first; version=2.24.4; provider=paxlogging, \
- org.apache.logging.log4j.util;-split-package:=merge-first; version=2.25.4; provider=paxlogging, \
  org.ops4j.pax.logging; version=${pom.version}; provider=paxlogging, \
  org.ops4j.pax.logging.spi; version=${pom.version}; provider=paxlogging, \
  org.osgi.service.log; version=1.4;-split-package:=merge-first, \

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
         <version.org.apache.felix.configadmin>1.9.26</version.org.apache.felix.configadmin>
         <version.org.apache.felix6.framework>6.0.5</version.org.apache.felix6.framework>
         <version.org.apache.felix7.framework>7.0.5</version.org.apache.felix7.framework>
-        <version.org.apache.logging.log4j>2.25.5</version.org.apache.logging.log4j>
+        <version.org.apache.logging.log4j>2.25.4</version.org.apache.logging.log4j>
         <version.org.apache.maven>3.9.9</version.org.apache.maven>
         <version.org.apache.maven.plugin-tools>3.15.1</version.org.apache.maven.plugin-tools>
         <version.org.apache.servicemix.bundles.javax-inject>1_3</version.org.apache.servicemix.bundles.javax-inject>


### PR DESCRIPTION
## Purpose
This reverts PR #34 (commit 1fbf71cd), which upgraded Log4j2 to 2.25.5.