### PR TITLE
[test] "Fix" timing issue with EventAdmin integration test (cherry-pick from ops4j upstream)

### DIFF
--- a/pax-logging-it/src/test/java/org/ops4j/pax/logging/it/EventAdminIntegrationTest.java
+++ b/pax-logging-it/src/test/java/org/ops4j/pax/logging/it/EventAdminIntegrationTest.java
@@ -91,6 +91,7 @@ public class EventAdminIntegrationTest extends AbstractControlledIntegrationTest
 
         logger.info("when log4j2 available (info)");
         logger.error("when log4j2 available (error)", new Exception("exception 3"));
+        Thread.sleep(200);
 
         Event e22 = ev(events, "when logback available (info)");
         Event e23 = ev(events, "when logback available (error)");


### PR DESCRIPTION
Cherry-picked from ops4j/org.ops4j.pax.logging@4b72ed26e66a0c9c90ebda366ff3c7242b775c0a

